### PR TITLE
Copy data into `d.originalBytes` in `parseDescriptors`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
  - Make ParseData public
  - Make `PacketPool` and `(p *PacketPool) Add()` public
  - Add all stream types values
+ - Copy data into `d.originalBytes` in `parseDescriptors`, as we cannot count on it persisting

--- a/descriptor.go
+++ b/descriptor.go
@@ -1299,10 +1299,14 @@ func parseDescriptors(i *astikit.BytesIterator) (o []*Descriptor, err error) {
 				// <Hack>: assign the original bytes to an internal byte slice for use when reserialising later
 				// TODO fix this to actually serialise the struct
 				origOffset := i.Offset()
-				if d.originalBytes, err = i.NextBytes(int(d.Length)); err != nil {
+				var origBytes []byte
+				if origBytes, err = i.NextBytes(int(d.Length)); err != nil {
 					err = fmt.Errorf("astits: fetching original bytes failed: %w", err)
 					return
 				}
+				// Can't count on the original byte array persisting, so create a copy
+				d.originalBytes = make([]byte, len(origBytes))
+				copy(d.originalBytes, origBytes)
 				// Reset iterator so parsing can continue
 				i.Seek(origOffset)
 				// </Hack>


### PR DESCRIPTION
If we are using `GetDataUnsafe` (see https://github.com/SpalkLtd/go-libav/pull/12 and https://github.com/SpalkLtd/synchroniser/pull/545) to get the data passed to `parseDescriptors`, we cannot count on it persisting at the point where we need to access `d.originalBytes`.