### PR TITLE
check len of buffer before indexing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+ - Length check array length before index use
+
 ## v1.5.0
  - Add serialisation methods for PAT and PMT packets
  - Make ParseData public

--- a/data_pat.go
+++ b/data_pat.go
@@ -43,6 +43,9 @@ func parsePATSection(i *astikit.BytesIterator, offsetSectionsEnd int, tableIDExt
 }
 
 func (p *PATData) Serialise(b []byte) (int, error) {
+	if len(b) == 0 {
+		return 0, ErrNoRoomInBuffer
+	}
 	currentIdx := 0
 	for i := range p.Programs {
 		n, err := p.Programs[i].Serialise(b[currentIdx:])

--- a/data_pmt.go
+++ b/data_pmt.go
@@ -148,7 +148,7 @@ func parsePMTSection(i *astikit.BytesIterator, offsetSectionsEnd int, tableIDExt
 }
 
 func (p *PMTData) Serialise(b []byte) (int, error) {
-	if len(b) < 4 {
+	if len(b) <= 4 {
 		return 0, ErrNoRoomInBuffer
 	}
 	b[0] = 0x7<<5 | uint8(0x1f&(p.PCRPID>>8))
@@ -176,7 +176,7 @@ func (p *PMTData) Serialise(b []byte) (int, error) {
 }
 
 func (pes *PMTElementaryStream) Serialise(b []byte) (int, error) {
-	if len(b) < 5 {
+	if len(b) <= 5 {
 		return 0, ErrNoRoomInBuffer
 	}
 	b[0] = pes.StreamType

--- a/data_psi.go
+++ b/data_psi.go
@@ -452,6 +452,9 @@ func (d *PSIData) toData(firstPacket *Packet, pid uint16) (ds []*Data) {
 }
 
 func (d *PSIData) Serialise(b []byte) (int, error) {
+	if len(b) <= 1 {
+		return 0, ErrNoRoomInBuffer
+	}
 
 	//TODO take care of pointer field
 	if d.PointerField != 0 {
@@ -479,7 +482,7 @@ func (s *PSISection) Serialise(b []byte) (int, error) {
 	if s.Header.TableID == 255 {
 		return 0, nil
 	}
-	if len(b) < 3 {
+	if len(b) <= 3 {
 		return 0, ErrNoRoomInBuffer
 	}
 	idx := 3 // Skip 3 byte header we put in afterward
@@ -549,6 +552,9 @@ func (h *PSISectionHeader) Serialise(b []byte) (int, error) {
 }
 
 func (s *PSISectionSyntax) Serialise(b []byte) (int, error) {
+	if len(b) == 0 {
+		return 0, ErrNoRoomInBuffer
+	}
 	idx := 0
 	if s.Header != nil {
 		n, err := s.Header.Serialise(b[idx:])

--- a/descriptor.go
+++ b/descriptor.go
@@ -1455,11 +1455,11 @@ func parseDescriptors(i *astikit.BytesIterator) (o []*Descriptor, err error) {
 }
 
 func (d *Descriptor) Serialise(b []byte) (int, error) {
-	b[0] = d.Tag
-	b[1] = d.Length
-	if len(b) < int(d.Length)+2 {
+	if len(b) < 3 || len(b) < int(d.Length)+2 {
 		return 0, ErrNoRoomInBuffer
 	}
+	b[0] = d.Tag
+	b[1] = d.Length
 	//TODO actually create the descriptor from the struct
 	copy(b[2:], d.originalBytes)
 	// +2 to account for the Tag and Length fields


### PR DESCRIPTION
This panicked for me when I was running it locally with the vbr multi packet stream test bc the length of the buffer was 5 and it set the index to 5. So I've found all places it does that when serialising and add a check first