### PR TITLE
Add NewUserDefinedDescriptor constructor

### DIFF
--- a/descriptor.go
+++ b/descriptor.go
@@ -1465,3 +1465,13 @@ func (d *Descriptor) Serialise(b []byte) (int, error) {
 	// +2 to account for the Tag and Length fields
 	return int(d.Length + 2), nil
 }
+
+// NewUserDefinedDescriptor returns a Descriptor that Serialises to tag | len(content) | content.
+// Use for application-specific descriptors that this package doesn't model explicitly.
+func NewUserDefinedDescriptor(tag uint8, content []byte) *Descriptor {
+	return &Descriptor{
+		Tag:           tag,
+		Length:        uint8(len(content)),
+		originalBytes: content,
+	}
+}

--- a/descriptor_test.go
+++ b/descriptor_test.go
@@ -386,3 +386,12 @@ func TestParseDescriptor(t *testing.T) {
 	})
 	assert.Equal(t, *ds[25].Extension.Unknown, []byte("test"))
 }
+
+func TestNewUserDefinedDescriptor(t *testing.T) {
+	d := NewUserDefinedDescriptor(0x86, []byte{0x01, 0x02, 0x03})
+	b := make([]byte, 8)
+	n, err := d.Serialise(b)
+	assert.NoError(t, err)
+	assert.Equal(t, 5, n)
+	assert.Equal(t, []byte{0x86, 0x03, 0x01, 0x02, 0x03}, b[:n])
+}


### PR DESCRIPTION
## Description

Adds `NewUserDefinedDescriptor(tag, content)` so callers can construct application-specific descriptors (e.g. caption_service_descriptor 0x86) without reflecting into the unexported `originalBytes` field. Pairs with SpalkLtd/synchroniser#1860 which currently uses `reflect.NewAt`+`unsafe.Pointer` to do this — that hack can go once this lands and the fork is bumped in go.work.
